### PR TITLE
Wrapping deflated streams in BufferedStream when reading

### DIFF
--- a/SharpNBT/NbtFile.cs
+++ b/SharpNBT/NbtFile.cs
@@ -175,8 +175,8 @@ public static class NbtFile
         return compression switch
         {
             CompressionType.None => stream,
-            CompressionType.GZip => new GZipStream(stream, CompressionMode.Decompress, false),
-            CompressionType.ZLib => new ZLibStream(stream, CompressionMode.Decompress),
+            CompressionType.GZip => new BufferedStream(new GZipStream(stream, CompressionMode.Decompress, false)),
+            CompressionType.ZLib => new BufferedStream(new ZLibStream(stream, CompressionMode.Decompress)),
             _ => throw new ArgumentOutOfRangeException(nameof(compression), compression, null)
         };
     }


### PR DESCRIPTION
Seems that by default `ZLibStream` and `GZipStream` don't buffer themselves when decompressing so reading in small chunks(which is the case with nbt tags) is not good for performance
https://github.com/dotnet/runtime/issues/39233

The speed of `NbtFile.Read()` that I measured:

- Reading a .mca region file(1024 nbts) combined into 1 large(~6MB) zlib .nbt | _zlib_
```
| Method   | Mean       | Error    | StdDev   |
|--------- |-----------:|---------:|---------:|
| Buffered |   296.9 ms |  5.29 ms |  5.19 ms |
| Current  | 1,197.6 ms | 15.89 ms | 14.86 ms |
```

- Reading N times the `\SharpNBT.Tests\Data\bigtest.nbt` | _gzip_
```
| Method   | N   | Mean        | Error     | StdDev    |
|--------- |---- |------------:|----------:|----------:|
| Buffered | 1   |    35.08 us |  0.701 us |  1.050 us |
| Current  | 1   |    42.24 us |  0.502 us |  0.470 us |
| Buffered | 100 | 3,374.03 us | 51.648 us | 43.128 us |
| Current  | 100 | 4,238.87 us | 82.226 us | 76.914 us |
```