### PR TITLE
Allow compound tag with empty name

### DIFF
--- a/SharpNBT/TagWriter.cs
+++ b/SharpNBT/TagWriter.cs
@@ -306,7 +306,7 @@ public class TagWriter : TagIO
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void WriteTypeAndName(Tag tag)
     {
-        if (tag.Parent is ListTag || string.IsNullOrEmpty(tag.Name))
+        if (tag.Parent is ListTag)
             return;
 
         BaseStream.WriteByte((byte) tag.Type);

--- a/SharpNBT/TagWriter.cs
+++ b/SharpNBT/TagWriter.cs
@@ -309,6 +309,9 @@ public class TagWriter : TagIO
         if (tag.Parent is ListTag)
             return;
 
+        if (string.IsNullOrEmpty(tag.Name) && !(tag is CompoundTag && tag.Parent is null))
+            return;
+
         BaseStream.WriteByte((byte) tag.Type);
         WriteUTF8String(tag.Name);
     }


### PR DESCRIPTION
Since this commit (https://github.com/ForeverZer0/SharpNBT/commit/bcd41b37f08fdade66f44ad4a71d2156cb06d750) it is not possible to write compound tag with empty name and the root tag name of the `level.dat` file generated by a minecraft server is empty.